### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
     The fastest way to build Python or JavaScript LLM apps with memory!
 </p>
 
+<a href="https://glama.ai/mcp/servers/@chroma-core/chroma-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chroma-core/chroma-mcp/badge" alt="Chroma Server MCP server" />
+</a>
+
 <p align="center">
   <a href="https://discord.gg/MMeYNTmh3x" target="_blank">
       <img src="https://img.shields.io/discord/1073293645303795742?cacheSeconds=3600" alt="Discord">


### PR DESCRIPTION
This PR adds a badge for the [Chroma MCP Server](https://glama.ai/mcp/servers/@chroma-core/chroma-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@chroma-core/chroma-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@chroma-core/chroma-mcp/badge" alt="Chroma Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.