### PR TITLE
chore(GitHub Action): adding container workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,56 @@
+name: Container Next
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to ghcr.io
+        run: podman login --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }} ${{ env.REGISTRY }}
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          # Extract tag name or use 'latest' for main branch
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=latest
+          fi
+          
+          IMAGE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}"
+          echo "tags=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Build container image
+        run: |
+          podman build \
+            --tag ${{ steps.meta.outputs.tags }} \
+            --file Dockerfile \
+            .
+
+      - name: Push container image
+        run: |
+          podman push ${{ steps.meta.outputs.tags }}
+
+      - name: Output image details
+        run: |
+          echo "Image pushed: ${{ steps.meta.outputs.tags }}"
+          echo "Version: ${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
## Description

I am using the [Dockerfile](https://github.com/chroma-core/chroma-mcp/blob/main/Dockerfile) from this repository, however it might be nice to have it up to date and officially published. 

Adding a simple workflow to build & push to the GitHub registry. I tried it on my fork (https://github.com/axel7083/chroma-mcp/pkgs/container/chroma-mcp)

it allows to start the MCP Server easily with a container engine

```
$: (podman | docker) run -it  ghcr.io/chroma-core/chroma-mcp:{tag}
[09/12/25 08:47:51] INFO     Anonymized telemetry enabled. See                     https://docs.trychroma.com/telemetry for more information.                                                                          posthog.py:22
Successfully initialized Chroma client
Starting MCP server
```