### PR TITLE
Add `--no-ssl-verify` option to disable SSL verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,22 +136,24 @@ production/deployment), add the following to your `claude_desktop_config.json` f
 "chroma": {
     "command": "uvx",
     "args": [
-      "chroma-mcp", 
-      "--client-type", 
-      "http", 
-      "--host", 
-      "your-host", 
-      "--port", 
-      "your-port", 
+      "chroma-mcp",
+      "--client-type",
+      "http",
+      "--host",
+      "your-host",
+      "--port",
+      "your-port",
       "--custom-auth-credentials",
       "your-custom-auth-credentials",
       "--ssl",
+      "true",
+      "--ssl-verify",
       "true"
     ]
 }
 ```
 
-This will create an HTTP client that connects to your self-hosted Chroma instance.
+This will create an HTTP client that connects to your self-hosted Chroma instance. You can set `--ssl-verify` to `false` if you need to disable SSL certificate verification (e.g., when using self-signed certificates).
 
 ### Demos
 
@@ -178,6 +180,7 @@ export CHROMA_HOST="your-host"
 export CHROMA_PORT="your-port"
 export CHROMA_CUSTOM_AUTH_CREDENTIALS="your-custom-auth-credentials"
 export CHROMA_SSL="true"
+export CHROMA_SSL_VERIFY="true"  # Set to "false" to disable SSL certificate verification
 
 # Optional: Specify path to .env file (defaults to .chroma_env)
 export CHROMA_DOTENV_PATH="/path/to/your/.env" 

--- a/README.md
+++ b/README.md
@@ -146,14 +146,12 @@ production/deployment), add the following to your `claude_desktop_config.json` f
       "--custom-auth-credentials",
       "your-custom-auth-credentials",
       "--ssl",
-      "true",
-      "--ssl-verify",
       "true"
     ]
 }
 ```
 
-This will create an HTTP client that connects to your self-hosted Chroma instance. You can set `--ssl-verify` to `false` if you need to disable SSL certificate verification (e.g., when using self-signed certificates).
+This will create an HTTP client that connects to your self-hosted Chroma instance. Add `--no-ssl-verify` flag if you need to disable SSL certificate verification (e.g., when using self-signed certificates).
 
 ### Demos
 
@@ -180,7 +178,7 @@ export CHROMA_HOST="your-host"
 export CHROMA_PORT="your-port"
 export CHROMA_CUSTOM_AUTH_CREDENTIALS="your-custom-auth-credentials"
 export CHROMA_SSL="true"
-export CHROMA_SSL_VERIFY="true"  # Set to "false" to disable SSL certificate verification
+export CHROMA_NO_SSL_VERIFY="true"  # Set to "true" to disable SSL certificate verification
 
 # Optional: Specify path to .env file (defaults to .chroma_env)
 export CHROMA_DOTENV_PATH="/path/to/your/.env" 

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -32,6 +32,10 @@ mcp = FastMCP("chroma")
 # Global variables
 _chroma_client = None
 
+def is_truthy(value: str) -> bool:
+    """Convert string value to boolean."""
+    return value.lower() in ['true', 'yes', '1', 't', 'y']
+
 def create_parser():
     """Create and return the argument parser."""
     parser = argparse.ArgumentParser(description='FastMCP server for Chroma DB')
@@ -62,12 +66,12 @@ def create_parser():
                        default=os.getenv('CHROMA_API_KEY'))
     parser.add_argument('--ssl',
                        help='Use SSL (optional for http client)',
-                       type=lambda x: x.lower() in ['true', 'yes', '1', 't', 'y'],
-                       default=os.getenv('CHROMA_SSL', 'true').lower() in ['true', 'yes', '1', 't', 'y'])
+                       type=is_truthy,
+                       default=is_truthy(os.getenv('CHROMA_SSL', 'true')))
     parser.add_argument('--ssl-verify',
                        help='Verify SSL certificates (optional for http client)',
-                       type=lambda x: x.lower() in ['true', 'yes', '1', 't', 'y'],
-                       default=os.getenv('CHROMA_SSL_VERIFY', 'true').lower() in ['true', 'yes', '1', 't', 'y'])
+                       type=is_truthy,
+                       default=is_truthy(os.getenv('CHROMA_SSL_VERIFY', 'true')))
     parser.add_argument('--dotenv-path',
                        help='Path to .env file',
                        default=os.getenv('CHROMA_DOTENV_PATH', '.chroma_env'))

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -68,11 +68,10 @@ def create_parser():
                        help='Use SSL (optional for http client)',
                        type=is_truthy,
                        default=is_truthy(os.getenv('CHROMA_SSL', 'true')))
-    ssl_verify_env = os.getenv('CHROMA_SSL_VERIFY')
-    parser.add_argument('--ssl-verify',
-                       help='Verify SSL certificates (optional for http client)',
-                       type=is_truthy,
-                       default=is_truthy(ssl_verify_env) if ssl_verify_env else None)
+    parser.add_argument('--no-ssl-verify',
+                       help='Disable SSL certificate verification',
+                       action='store_true',
+                       default=is_truthy(os.getenv('CHROMA_NO_SSL_VERIFY', 'false')))
     parser.add_argument('--dotenv-path',
                        help='Path to .env file',
                        default=os.getenv('CHROMA_DOTENV_PATH', '.chroma_env'))
@@ -95,8 +94,8 @@ def get_chroma_client(args=None):
 
             # Build settings dict
             settings_dict = {}
-            if args.ssl_verify is not None:
-                settings_dict["chroma_server_ssl_verify"] = args.ssl_verify
+            if args.no_ssl_verify:
+                settings_dict["chroma_server_ssl_verify"] = False
 
             if args.custom_auth_credentials:
                 settings_dict["chroma_client_auth_provider"] = "chromadb.auth.basic_authn.BasicAuthClientProvider"

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -68,10 +68,11 @@ def create_parser():
                        help='Use SSL (optional for http client)',
                        type=is_truthy,
                        default=is_truthy(os.getenv('CHROMA_SSL', 'true')))
+    ssl_verify_env = os.getenv('CHROMA_SSL_VERIFY')
     parser.add_argument('--ssl-verify',
                        help='Verify SSL certificates (optional for http client)',
                        type=is_truthy,
-                       default=is_truthy(os.getenv('CHROMA_SSL_VERIFY', 'true')))
+                       default=is_truthy(ssl_verify_env) if ssl_verify_env else None)
     parser.add_argument('--dotenv-path',
                        help='Path to .env file',
                        default=os.getenv('CHROMA_DOTENV_PATH', '.chroma_env'))
@@ -94,7 +95,8 @@ def get_chroma_client(args=None):
 
             # Build settings dict
             settings_dict = {}
-            settings_dict["chroma_server_ssl_verify"] = args.ssl_verify
+            if args.ssl_verify is not None:
+                settings_dict["chroma_server_ssl_verify"] = args.ssl_verify
 
             if args.custom_auth_credentials:
                 settings_dict["chroma_client_auth_provider"] = "chromadb.auth.basic_authn.BasicAuthClientProvider"

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -60,12 +60,16 @@ def create_parser():
     parser.add_argument('--api-key', 
                        help='Chroma API key (required if tenant is provided)', 
                        default=os.getenv('CHROMA_API_KEY'))
-    parser.add_argument('--ssl', 
-                       help='Use SSL (optional for http client)', 
+    parser.add_argument('--ssl',
+                       help='Use SSL (optional for http client)',
                        type=lambda x: x.lower() in ['true', 'yes', '1', 't', 'y'],
                        default=os.getenv('CHROMA_SSL', 'true').lower() in ['true', 'yes', '1', 't', 'y'])
-    parser.add_argument('--dotenv-path', 
-                       help='Path to .env file', 
+    parser.add_argument('--ssl-verify',
+                       help='Verify SSL certificates (optional for http client)',
+                       type=lambda x: x.lower() in ['true', 'yes', '1', 't', 'y'],
+                       default=os.getenv('CHROMA_SSL_VERIFY', 'true').lower() in ['true', 'yes', '1', 't', 'y'])
+    parser.add_argument('--dotenv-path',
+                       help='Path to .env file',
                        default=os.getenv('CHROMA_DOTENV_PATH', '.chroma_env'))
     return parser
 
@@ -83,13 +87,16 @@ def get_chroma_client(args=None):
         if args.client_type == 'http':
             if not args.host:
                 raise ValueError("Host must be provided via --host flag or CHROMA_HOST environment variable when using HTTP client")
-            
-            settings = Settings()
+
+            # Build settings dict
+            settings_dict = {}
+            settings_dict["chroma_server_ssl_verify"] = args.ssl_verify
+
             if args.custom_auth_credentials:
-                settings = Settings(
-                    chroma_client_auth_provider="chromadb.auth.basic_authn.BasicAuthClientProvider",
-                    chroma_client_auth_credentials=args.custom_auth_credentials
-                )
+                settings_dict["chroma_client_auth_provider"] = "chromadb.auth.basic_authn.BasicAuthClientProvider"
+                settings_dict["chroma_client_auth_credentials"] = args.custom_auth_credentials
+
+            settings = Settings(**settings_dict)
             
             # Handle SSL configuration
             try:


### PR DESCRIPTION
There was a use case where we needed to disable ssl_verify in ChromaDB's HTTPClient.

Since the current MCP implementation doesn't allow passing arbitrary Settings and designing a CLI is difficult, we added the `—no-ssl-verify` option.
https://github.com/chroma-core/chroma/blob/main/chromadb/config.py#L152