### PR TITLE
feat: add Ollama and SentenceTransformer to embedding function registry

### DIFF
--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -24,6 +24,8 @@ from chromadb.utils.embedding_functions import (
     JinaEmbeddingFunction,
     VoyageAIEmbeddingFunction,
     RoboflowEmbeddingFunction,
+    OllamaEmbeddingFunction,
+    SentenceTransformerEmbeddingFunction,
 )
 
 # Initialize FastMCP server
@@ -175,6 +177,8 @@ mcp_known_embedding_functions: Dict[str, EmbeddingFunction] = {
     "jina": JinaEmbeddingFunction,
     "voyageai": VoyageAIEmbeddingFunction,
     "roboflow": RoboflowEmbeddingFunction,
+    "ollama": OllamaEmbeddingFunction,
+    "sentence_transformer": SentenceTransformerEmbeddingFunction,
 }
 @mcp.tool()
 async def chroma_create_collection(
@@ -186,7 +190,7 @@ async def chroma_create_collection(
     
     Args:
         collection_name: Name of the collection to create
-        embedding_function_name: Name of the embedding function to use. Options: 'default', 'cohere', 'openai', 'jina', 'voyageai', 'ollama', 'roboflow'
+        embedding_function_name: Name of the embedding function to use. Options: 'default', 'cohere', 'openai', 'jina', 'voyageai', 'roboflow', 'ollama', 'sentence_transformer'
         metadata: Optional metadata dict to add to the collection
     """
     client = get_chroma_client()


### PR DESCRIPTION
## Summary

- Register `OllamaEmbeddingFunction` and `SentenceTransformerEmbeddingFunction` from chromadb's built-in embedding functions into `mcp_known_embedding_functions`
- Users can now select local embedding models when creating collections via `embedding_function_name` parameter
- Both are optional dependencies — only needed when explicitly selected

## Motivation

Currently `mcp_known_embedding_functions` only includes cloud-based providers (OpenAI, Cohere, Jina, VoyageAI) plus the default ONNX model. However, chromadb already ships with `OllamaEmbeddingFunction` and `SentenceTransformerEmbeddingFunction` for local inference. Users who want to use local models (for privacy, cost, or latency reasons) have to manually modify `server.py`.

This PR simply imports and registers these two existing functions — no new code, just 5 lines changed.

Closes #42
Related to #7, alternative lightweight approach to #37

## Changes

`src/chroma_mcp/server.py`:
1. Added imports for `OllamaEmbeddingFunction` and `SentenceTransformerEmbeddingFunction`
2. Registered them in `mcp_known_embedding_functions` as `"ollama"` and `"sentence_transformer"`
3. Updated docstring to list the new options

## Usage

```python
# Ollama (requires: pip install ollama, and Ollama running locally)
chroma_create_collection(collection_name="my_col", embedding_function_name="ollama")

# SentenceTransformer (requires: pip install sentence-transformers)
chroma_create_collection(collection_name="my_col", embedding_function_name="sentence_transformer")
```

## Test plan

- [x] Verify imports resolve without error when dependencies are installed
- [x] Create a collection with `embedding_function_name="ollama"` and confirm embeddings are generated locally
- [x] Create a collection with `embedding_function_name="sentence_transformer"` and confirm local inference
- [x] Verify existing `"default"` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)