### PR TITLE
Fix stdio protocol corruption by sending startup/error messages to stderr

### DIFF
--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 import argparse
 from chromadb.config import Settings
 import ssl
+import sys
 import uuid
 import time
 import json
@@ -100,10 +101,10 @@ def get_chroma_client(args=None):
                     settings=settings
                 )
             except ssl.SSLError as e:
-                print(f"SSL connection failed: {str(e)}")
+                print(f"SSL connection failed: {str(e)}", file=sys.stderr)
                 raise
             except Exception as e:
-                print(f"Error connecting to HTTP client: {str(e)}")
+                print(f"Error connecting to HTTP client: {str(e)}", file=sys.stderr)
                 raise
             
         elif args.client_type == 'cloud':
@@ -125,10 +126,10 @@ def get_chroma_client(args=None):
                     }
                 )
             except ssl.SSLError as e:
-                print(f"SSL connection failed: {str(e)}")
+                print(f"SSL connection failed: {str(e)}", file=sys.stderr)
                 raise
             except Exception as e:
-                print(f"Error connecting to cloud client: {str(e)}")
+                print(f"Error connecting to cloud client: {str(e)}", file=sys.stderr)
                 raise
                 
         elif args.client_type == 'persistent':
@@ -657,13 +658,13 @@ def main():
     # Initialize client with parsed args
     try:
         get_chroma_client(args)
-        print("Successfully initialized Chroma client")
+        print("Successfully initialized Chroma client", file=sys.stderr)
     except Exception as e:
-        print(f"Failed to initialize Chroma client: {str(e)}")
+        print(f"Failed to initialize Chroma client: {str(e)}", file=sys.stderr)
         raise
     
     # Initialize and run the server
-    print("Starting MCP server")
+    print("Starting MCP server", file=sys.stderr)
     mcp.run(transport='stdio')
     
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

I noticed this after switching from claude to codex - it's a trivial fix so figured it was simple enough to PR.  I've been using chroma-mcp for months and it's part of my daily workflow, so was motivated to fix it!
 
I believe chroma-mcp currently prints several human-readable startup and error messages to stdout in src/chroma_mcp/server.py.

That is unsafe for a stdio MCP server.  In stdio MCP, stdout must be reserved for MCP protocol frames only. Any plain-text output on stdout can corrupt the transport for strict clients.

This PR redirects those human-readable messages to stderr instead of stdout.

Changed messages:
  - HTTP connection error prints
  - cloud connection error prints
  - Successfully initialized Chroma client
  - Failed to initialize Chroma client: ...
  - Starting MCP server

Why this matters:
  - some MCP clients appear to tolerate this extra stdout output
  - others do not
  - in particular, OpenAI Codex failed reliably when chroma_query_documents was invoked through the real stdio MCP path

Observed Codex failure:
  - serde error expected value at line 1 column 1
  - followed by Transport closed

The direct cause was that Codex tried to parse non-JSON bytes from the stdio stream.

This patch does not change MCP behavior or Chroma behavior. It only ensures that non-protocol diagnostic output goes to stderr, which is the correct channel for a stdio MCP server.

Tested on Debian 12 Linux with chroma-mcp used as a direct stdio MCP server.

Before this patch:
  - manual direct Chroma Python queries worked
  - a manual Python MCP stdio client worked
  - Claude worked too -
  - Codex could often call simple tools like chroma_list_collections
  - but Codex chroma_query_documents calls failed with:
      **- serde error expected value at line 1 column 1**
      **- Transport closed**

After this patch:
  - real Codex direct stdio MCP queries succeeded
  - specifically:
      - chroma_query_documents
      - collection: my-rag-collection
      - query: ["something interesting"]
      - result returned successfully


