### PR TITLE
Bugs Fixes: LLM failed to generate correct tool calling command due to a poor generated schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
       <img src="https://img.shields.io/discord/1073293645303795742?cacheSeconds=3600" alt="Discord">
   </a> |
   <a href="https://github.com/chroma-core/chroma/blob/master/LICENSE" target="_blank">
-      <img src="https://img.shields.io/static/v1?label=license&message=Apache 2.0&color=white" alt="License">
+      <img src="https://img.shields.io/github/license/CharliiKo/chroma-mcp.svg" alt="License">
   </a> |
   <a href="https://docs.trychroma.com/" target="_blank">
       Docs

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -140,6 +140,41 @@ def get_chroma_client(args=None):
             
     return _chroma_client
 
+##### Parse Tools #####
+
+def _parse_dict_param(value: str | Dict | None, param_name: str) -> Dict | None:
+    """Parse a dict parameter that may come as a JSON string.
+    
+    Agent frameworks pass JSON objects as strings (e.g., '{"$contains": "Python"}'),
+    so we accept string input and parse it into a dict. Dict input is also accepted
+    for backward compatibility with direct Python callers.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, dict):
+                raise ValueError(
+                    f"Parameter '{param_name}' must be a JSON object, "
+                    f"got {type(parsed).__name__}: {value}"
+                )
+            return parsed
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Parameter '{param_name}' is not valid JSON: {value}. "
+                f"Error: {str(e)}"
+            ) from e
+    raise ValueError(
+        f"Parameter '{param_name}' must be a dict or JSON string, "
+        f"got {type(value).__name__}"
+    )
+
 ##### Collection Tools #####
 
 @mcp.tool()
@@ -180,15 +215,16 @@ mcp_known_embedding_functions: Dict[str, EmbeddingFunction] = {
 async def chroma_create_collection(
     collection_name: str,
     embedding_function_name: str = "default",
-    metadata: Dict | None = None,
+    metadata: str | Dict | None = None,
 ) -> str:
     """Create a new Chroma collection with configurable HNSW parameters.
     
     Args:
         collection_name: Name of the collection to create
         embedding_function_name: Name of the embedding function to use. Options: 'default', 'cohere', 'openai', 'jina', 'voyageai', 'ollama', 'roboflow'
-        metadata: Optional metadata dict to add to the collection
+        metadata: Optional metadata dict as a JSON string or Dict (e.g., '{"key": "value"}' or {"key": "value"})
     """
+    metadata = _parse_dict_param(metadata, "metadata")
     client = get_chroma_client()
     
     embedding_function = mcp_known_embedding_functions[embedding_function_name]
@@ -270,15 +306,16 @@ async def chroma_get_collection_count(collection_name: str) -> int:
 async def chroma_modify_collection(
     collection_name: str,
     new_name: str | None = None,
-    new_metadata: Dict | None = None,
+    new_metadata: str | Dict | None = None,
 ) -> str:
     """Modify a Chroma collection's name or metadata.
     
     Args:
         collection_name: Name of the collection to modify
         new_name: Optional new name for the collection
-        new_metadata: Optional new metadata for the collection
+        new_metadata: Optional new metadata for the collection as a JSON string or Dict
     """
+    new_metadata = _parse_dict_param(new_metadata, "new_metadata")
     client = get_chroma_client()
     try:
         collection = client.get_collection(collection_name)
@@ -328,13 +365,42 @@ async def chroma_delete_collection(collection_name: str) -> str:
     except Exception as e:
         raise Exception(f"Failed to delete collection '{collection_name}': {str(e)}") from e
 
-##### Document Tools #####
+
+def _parse_list_dict_param(value: str | List[Dict] | None, param_name: str) -> List[Dict] | None:
+    """Parse a list-of-dicts parameter that may come as a JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, list):
+                raise ValueError(
+                    f"Parameter '{param_name}' must be a JSON array, "
+                    f"got {type(parsed).__name__}: {value}"
+                )
+            return parsed
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Parameter '{param_name}' is not valid JSON: {value}. "
+                f"Error: {str(e)}"
+            ) from e
+    raise ValueError(
+        f"Parameter '{param_name}' must be a list or JSON string, "
+        f"got {type(value).__name__}"
+    )
+
+
 @mcp.tool()
 async def chroma_add_documents(
     collection_name: str,
     documents: List[str],
     ids: List[str],
-    metadatas: List[Dict] | None = None
+    metadatas: str | List[Dict] | None = None
 ) -> str:
     """Add documents to a Chroma collection.
     
@@ -342,8 +408,10 @@ async def chroma_add_documents(
         collection_name: Name of the collection to add documents to
         documents: List of text documents to add
         ids: List of IDs for the documents (required)
-        metadatas: Optional list of metadata dictionaries for each document
+        metadatas: Optional list of metadata dictionaries as a JSON string or List[Dict]
+                   (e.g., '[{"key": "value"}]' or [{"key": "value"}])
     """
+    metadatas = _parse_list_dict_param(metadatas, "metadatas")
     if not documents:
         raise ValueError("The 'documents' list cannot be empty.")
     
@@ -397,8 +465,8 @@ async def chroma_query_documents(
     collection_name: str,
     query_texts: List[str],
     n_results: int = 5,
-    where: Dict | None = None,
-    where_document: Dict | None = None,
+    where: str | Dict | None = None,
+    where_document: str | Dict | None = None,
     include: List[str] = ["documents", "metadatas", "distances"]
 ) -> Dict:
     """Query documents from a Chroma collection with advanced filtering.
@@ -407,24 +475,27 @@ async def chroma_query_documents(
         collection_name: Name of the collection to query
         query_texts: List of query texts to search for
         n_results: Number of results to return per query
-        where: Optional metadata filters using Chroma's query operators
+        where: Optional metadata filters as a JSON string or Dict using Chroma's query operators
                Examples:
-               - Simple equality: {"metadata_field": "value"}
-               - Comparison: {"metadata_field": {"$gt": 5}}
-               - Logical AND: {"$and": [{"field1": {"$eq": "value1"}}, {"field2": {"$gt": 5}}]}
-               - Logical OR: {"$or": [{"field1": {"$eq": "value1"}}, {"field1": {"$eq": "value2"}}]}
-        where_document: Optional document content filters
+               - Simple equality: '{"metadata_field": "value"}' or {"metadata_field": "value"}
+               - Comparison: '{"metadata_field": {"$gt": 5}}'
+               - Logical AND: '{"$and": [{"field1": {"$eq": "value1"}}, {"field2": {"$gt": 5}}]}'
+               - Logical OR: '{"$or": [{"field1": {"$eq": "value1"}}, {"field1": {"$eq": "value2"}}]}'
+        where_document: Optional document content filters as a JSON string or Dict
                Examples:
-               - Contains: {"$contains": "value"}
-               - Not contains: {"$not_contains": "value"}
-               - Regex: {"$regex": "[a-z]+"}
-               - Not regex: {"$not_regex": "[a-z]+"}
-               - Logical AND: {"$and": [{"$contains": "value1"}, {"$not_regex": "[a-z]+"}]}
-               - Logical OR: {"$or": [{"$regex": "[a-z]+"}, {"$not_contains": "value2"}]}
+               - Contains: '{"$contains": "value"}'
+               - Not contains: '{"$not_contains": "value"}'
+               - Regex: '{"$regex": "[a-z]+"}'
+               - Not regex: '{"$not_regex": "[a-z]+"}'
+               - Logical AND: '{"$and": [{"$contains": "value1"}, {"$not_regex": "[a-z]+"}]}'
+               - Logical OR: '{"$or": [{"$regex": "[a-z]+"}, {"$not_contains": "value2"}]}'
         include: List of what to include in response. By default, this will include documents, metadatas, and distances.
     """
     if not query_texts:
         raise ValueError("The 'query_texts' list cannot be empty.")
+
+    where = _parse_dict_param(where, "where")
+    where_document = _parse_dict_param(where_document, "where_document")
 
     client = get_chroma_client()
     try:
@@ -443,8 +514,8 @@ async def chroma_query_documents(
 async def chroma_get_documents(
     collection_name: str,
     ids: List[str] | None = None,
-    where: Dict | None = None,
-    where_document: Dict | None = None,
+    where: str | Dict | None = None,
+    where_document: str | Dict | None = None,
     include: List[str] = ["documents", "metadatas"],
     limit: int | None = None,
     offset: int | None = None
@@ -454,20 +525,20 @@ async def chroma_get_documents(
     Args:
         collection_name: Name of the collection to get documents from
         ids: Optional list of document IDs to retrieve
-        where: Optional metadata filters using Chroma's query operators
+        where: Optional metadata filters as a JSON string or Dict using Chroma's query operators
                Examples:
-               - Simple equality: {"metadata_field": "value"}
-               - Comparison: {"metadata_field": {"$gt": 5}}
-               - Logical AND: {"$and": [{"field1": {"$eq": "value1"}}, {"field2": {"$gt": 5}}]}
-               - Logical OR: {"$or": [{"field1": {"$eq": "value1"}}, {"field1": {"$eq": "value2"}}]}
-        where_document: Optional document content filters
+               - Simple equality: '{"metadata_field": "value"}' or {"metadata_field": "value"}
+               - Comparison: '{"metadata_field": {"$gt": 5}}'
+               - Logical AND: '{"$and": [{"field1": {"$eq": "value1"}}, {"field2": {"$gt": 5}}]}'
+               - Logical OR: '{"$or": [{"field1": {"$eq": "value1"}}, {"field1": {"$eq": "value2"}}]}'
+        where_document: Optional document content filters as a JSON string or Dict
                Examples:
-               - Contains: {"$contains": "value"}
-               - Not contains: {"$not_contains": "value"}
-               - Regex: {"$regex": "[a-z]+"}
-               - Not regex: {"$not_regex": "[a-z]+"}
-               - Logical AND: {"$and": [{"$contains": "value1"}, {"$not_regex": "[a-z]+"}]}
-               - Logical OR: {"$or": [{"$regex": "[a-z]+"}, {"$not_contains": "value2"}]}
+               - Contains: '{"$contains": "value"}'
+               - Not contains: '{"$not_contains": "value"}'
+               - Regex: '{"$regex": "[a-z]+"}'
+               - Not regex: '{"$not_regex": "[a-z]+"}'
+               - Logical AND: '{"$and": [{"$contains": "value1"}, {"$not_regex": "[a-z]+"}]}'
+               - Logical OR: '{"$or": [{"$regex": "[a-z]+"}, {"$not_contains": "value2"}]}'
         include: List of what to include in response. By default, this will include documents, and metadatas.
         limit: Optional maximum number of documents to return
         offset: Optional number of documents to skip before returning results
@@ -475,6 +546,8 @@ async def chroma_get_documents(
     Returns:
         Dictionary containing the matching documents, their IDs, and requested includes
     """
+    where = _parse_dict_param(where, "where")
+    where_document = _parse_dict_param(where_document, "where_document")
     client = get_chroma_client()
     try:
         collection = client.get_collection(collection_name)
@@ -494,7 +567,7 @@ async def chroma_update_documents(
     collection_name: str,
     ids: List[str],
     embeddings: List[List[float]] | None = None,
-    metadatas: List[Dict] | None = None,
+    metadatas: str | List[Dict] | None = None,
     documents: List[str] | None = None
 ) -> str:
     """Update documents in a Chroma collection.
@@ -504,8 +577,8 @@ async def chroma_update_documents(
         ids: List of document IDs to update (required)
         embeddings: Optional list of new embeddings for the documents.
                     Must match length of ids if provided.
-        metadatas: Optional list of new metadata dictionaries for the documents.
-                   Must match length of ids if provided.
+        metadatas: Optional list of new metadata dictionaries as a JSON string or List[Dict]
+                   (e.g., '[{"key": "value"}]' or [{"key": "value"}]). Must match length of ids if provided.
         documents: Optional list of new text documents.
                    Must match length of ids if provided.
 
@@ -518,6 +591,7 @@ async def chroma_update_documents(
                     update lists does not match the length of 'ids'.
         Exception: If the collection does not exist or if the update operation fails.
     """
+    metadatas = _parse_list_dict_param(metadatas, "metadatas")
     if not ids:
         raise ValueError("The 'ids' list cannot be empty.")
 

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -174,6 +174,35 @@ def _parse_dict_param(value: str | Dict | None, param_name: str) -> Dict | None:
         f"Parameter '{param_name}' must be a dict or JSON string, "
         f"got {type(value).__name__}"
     )
+    
+
+def _parse_list_dict_param(value: str | List[Dict] | None, param_name: str) -> List[Dict] | None:
+    """Parse a list-of-dicts parameter that may come as a JSON string."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, list):
+                raise ValueError(
+                    f"Parameter '{param_name}' must be a JSON array, "
+                    f"got {type(parsed).__name__}: {value}"
+                )
+            return parsed
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Parameter '{param_name}' is not valid JSON: {value}. "
+                f"Error: {str(e)}"
+            ) from e
+    raise ValueError(
+        f"Parameter '{param_name}' must be a list or JSON string, "
+        f"got {type(value).__name__}"
+    )
 
 ##### Collection Tools #####
 
@@ -364,35 +393,6 @@ async def chroma_delete_collection(collection_name: str) -> str:
         return f"Successfully deleted collection {collection_name}"
     except Exception as e:
         raise Exception(f"Failed to delete collection '{collection_name}': {str(e)}") from e
-
-
-def _parse_list_dict_param(value: str | List[Dict] | None, param_name: str) -> List[Dict] | None:
-    """Parse a list-of-dicts parameter that may come as a JSON string."""
-    if value is None:
-        return None
-    if isinstance(value, list):
-        return value
-    if isinstance(value, str):
-        value = value.strip()
-        if not value:
-            return None
-        try:
-            parsed = json.loads(value)
-            if not isinstance(parsed, list):
-                raise ValueError(
-                    f"Parameter '{param_name}' must be a JSON array, "
-                    f"got {type(parsed).__name__}: {value}"
-                )
-            return parsed
-        except json.JSONDecodeError as e:
-            raise ValueError(
-                f"Parameter '{param_name}' is not valid JSON: {value}. "
-                f"Error: {str(e)}"
-            ) from e
-    raise ValueError(
-        f"Parameter '{param_name}' must be a list or JSON string, "
-        f"got {type(value).__name__}"
-    )
 
 
 @mcp.tool()

--- a/src/chroma_mcp/server.py
+++ b/src/chroma_mcp/server.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, TypedDict, Union
+from typing import Dict, List, Optional, TypedDict, Union
 from enum import Enum
 import chromadb
 from mcp.server.fastmcp import FastMCP
@@ -204,12 +204,47 @@ def _parse_list_dict_param(value: str | List[Dict] | None, param_name: str) -> L
         f"got {type(value).__name__}"
     )
 
+
+def _parse_list_param(value: str | List | None, param_name: str) -> List | None:
+    """Parse a list parameter that may come as a JSON string.
+
+    Agent frameworks pass JSON arrays as strings (e.g., '["id1","id2"]'),
+    so we accept string input and parse it into a list. List input is also
+    accepted for backward compatibility with direct Python callers.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            parsed = json.loads(value)
+            if not isinstance(parsed, list):
+                raise ValueError(
+                    f"Parameter '{param_name}' must be a JSON array, "
+                    f"got {type(parsed).__name__}: {value}"
+                )
+            return parsed
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Parameter '{param_name}' is not valid JSON: {value}. "
+                f"Error: {str(e)}"
+            ) from e
+    raise ValueError(
+        f"Parameter '{param_name}' must be a list or JSON string, "
+        f"got {type(value).__name__}"
+    )
+
+
 ##### Collection Tools #####
 
 @mcp.tool()
 async def chroma_list_collections(
-    limit: int | None = None,
-    offset: int | None = None
+    limit: Optional[int] = None,
+    offset: Optional[int] = None
 ) -> List[str]:
     """List all collection names in the Chroma database with pagination support.
     
@@ -244,7 +279,7 @@ mcp_known_embedding_functions: Dict[str, EmbeddingFunction] = {
 async def chroma_create_collection(
     collection_name: str,
     embedding_function_name: str = "default",
-    metadata: str | Dict | None = None,
+    metadata: Optional[Union[str, Dict]] = None,
 ) -> str:
     """Create a new Chroma collection with configurable HNSW parameters.
     
@@ -334,8 +369,8 @@ async def chroma_get_collection_count(collection_name: str) -> int:
 @mcp.tool()
 async def chroma_modify_collection(
     collection_name: str,
-    new_name: str | None = None,
-    new_metadata: str | Dict | None = None,
+    new_name: Optional[str] = None,
+    new_metadata: Optional[Union[str, Dict]] = None,
 ) -> str:
     """Modify a Chroma collection's name or metadata.
     
@@ -398,20 +433,22 @@ async def chroma_delete_collection(collection_name: str) -> str:
 @mcp.tool()
 async def chroma_add_documents(
     collection_name: str,
-    documents: List[str],
-    ids: List[str],
-    metadatas: str | List[Dict] | None = None
+    documents: Union[str, List[str]],
+    ids: Union[str, List[str]],
+    metadatas: Optional[Union[str, List[Dict]]] = None
 ) -> str:
     """Add documents to a Chroma collection.
     
     Args:
         collection_name: Name of the collection to add documents to
-        documents: List of text documents to add
-        ids: List of IDs for the documents (required)
+        documents: List of text documents to add, or a JSON string array (e.g., '["doc1","doc2"]')
+        ids: List of IDs for the documents (required), or a JSON string array (e.g., '["id1","id2"]')
         metadatas: Optional list of metadata dictionaries as a JSON string or List[Dict]
                    (e.g., '[{"key": "value"}]' or [{"key": "value"}])
     """
     metadatas = _parse_list_dict_param(metadatas, "metadatas")
+    documents = _parse_list_param(documents, "documents")
+    ids = _parse_list_param(ids, "ids")
     if not documents:
         raise ValueError("The 'documents' list cannot be empty.")
     
@@ -463,17 +500,17 @@ async def chroma_add_documents(
 @mcp.tool()
 async def chroma_query_documents(
     collection_name: str,
-    query_texts: List[str],
+    query_texts: Union[str, List[str]],
     n_results: int = 5,
-    where: str | Dict | None = None,
-    where_document: str | Dict | None = None,
-    include: List[str] = ["documents", "metadatas", "distances"]
+    where: Optional[Union[str, Dict]] = None,
+    where_document: Optional[Union[str, Dict]] = None,
+    include: Union[str, List[str]] = "[\"documents\", \"metadatas\", \"distances\"]"
 ) -> Dict:
     """Query documents from a Chroma collection with advanced filtering.
     
     Args:
         collection_name: Name of the collection to query
-        query_texts: List of query texts to search for
+        query_texts: List of query texts to search for, or a JSON string array (e.g., '["text1","text2"]')
         n_results: Number of results to return per query
         where: Optional metadata filters as a JSON string or Dict using Chroma's query operators
                Examples:
@@ -494,6 +531,8 @@ async def chroma_query_documents(
     if not query_texts:
         raise ValueError("The 'query_texts' list cannot be empty.")
 
+    query_texts = _parse_list_param(query_texts, "query_texts")
+    include = _parse_list_param(include, "include")
     where = _parse_dict_param(where, "where")
     where_document = _parse_dict_param(where_document, "where_document")
 
@@ -513,18 +552,18 @@ async def chroma_query_documents(
 @mcp.tool()
 async def chroma_get_documents(
     collection_name: str,
-    ids: List[str] | None = None,
-    where: str | Dict | None = None,
-    where_document: str | Dict | None = None,
-    include: List[str] = ["documents", "metadatas"],
-    limit: int | None = None,
-    offset: int | None = None
+    ids: Optional[Union[str, List[str]]] = None,
+    where: Optional[Union[str, Dict]] = None,
+    where_document: Optional[Union[str, Dict]] = None,
+    include: Union[str, List[str]] = "[\"documents\", \"metadatas\"]",
+    limit: Optional[int] = None,
+    offset: Optional[int] = None
 ) -> Dict:
     """Get documents from a Chroma collection with optional filtering.
     
     Args:
         collection_name: Name of the collection to get documents from
-        ids: Optional list of document IDs to retrieve
+        ids: Optional list of document IDs to retrieve, or a JSON string array (e.g., '["id1","id2"]')
         where: Optional metadata filters as a JSON string or Dict using Chroma's query operators
                Examples:
                - Simple equality: '{"metadata_field": "value"}' or {"metadata_field": "value"}
@@ -548,6 +587,8 @@ async def chroma_get_documents(
     """
     where = _parse_dict_param(where, "where")
     where_document = _parse_dict_param(where_document, "where_document")
+    ids = _parse_list_param(ids, "ids")
+    include = _parse_list_param(include, "include")
     client = get_chroma_client()
     try:
         collection = client.get_collection(collection_name)
@@ -565,16 +606,16 @@ async def chroma_get_documents(
 @mcp.tool()
 async def chroma_update_documents(
     collection_name: str,
-    ids: List[str],
-    embeddings: List[List[float]] | None = None,
-    metadatas: str | List[Dict] | None = None,
-    documents: List[str] | None = None
+    ids: Union[str, List[str]],
+    embeddings: Optional[Union[str, List[List[float]]]] = None,
+    metadatas: Optional[Union[str, List[Dict]]] = None,
+    documents: Optional[Union[str, List[str]]] = None
 ) -> str:
     """Update documents in a Chroma collection.
 
     Args:
         collection_name: Name of the collection to update documents in
-        ids: List of document IDs to update (required)
+        ids: List of document IDs to update (required), or a JSON string array (e.g., '["id1","id2"]')
         embeddings: Optional list of new embeddings for the documents.
                     Must match length of ids if provided.
         metadatas: Optional list of new metadata dictionaries as a JSON string or List[Dict]
@@ -592,6 +633,9 @@ async def chroma_update_documents(
         Exception: If the collection does not exist or if the update operation fails.
     """
     metadatas = _parse_list_dict_param(metadatas, "metadatas")
+    ids = _parse_list_param(ids, "ids")
+    embeddings = _parse_list_param(embeddings, "embeddings")
+    documents = _parse_list_param(documents, "documents")
     if not ids:
         raise ValueError("The 'ids' list cannot be empty.")
 
@@ -641,13 +685,13 @@ async def chroma_update_documents(
 @mcp.tool()
 async def chroma_delete_documents(
     collection_name: str,
-    ids: List[str]
+    ids: Union[str, List[str]]
 ) -> str:
     """Delete documents from a Chroma collection.
 
     Args:
         collection_name: Name of the collection to delete documents from
-        ids: List of document IDs to delete
+        ids: List of document IDs to delete, or a JSON string array (e.g., '["id1","id2"]')
 
     Returns:
         A confirmation message indicating the number of documents deleted.
@@ -659,6 +703,7 @@ async def chroma_delete_documents(
     if not ids:
         raise ValueError("The 'ids' list cannot be empty.")
 
+    ids = _parse_list_param(ids, "ids")
     client = get_chroma_client()
     try:
         collection = client.get_collection(collection_name)

--- a/tests/test_chroma_get_documents.py
+++ b/tests/test_chroma_get_documents.py
@@ -1,0 +1,289 @@
+import sys
+import os
+
+# Ensure src directory is in Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import asyncio
+import argparse
+from chroma_mcp.server import (
+    get_chroma_client,
+    chroma_create_collection,
+    chroma_add_documents,
+    chroma_get_documents,
+    chroma_delete_collection,
+    _chroma_client,
+)
+
+
+def init_client():
+    """Initialize ephemeral Chroma client"""
+    global _chroma_client
+    args = argparse.Namespace(
+        client_type='ephemeral',
+        data_dir=None,
+        host=None,
+        port=None,
+        custom_auth_credentials=None,
+        tenant=None,
+        database=None,
+        api_key=None,
+        ssl=True,
+        dotenv_path='.chroma_env',
+    )
+    get_chroma_client(args)
+    print("✅ Chroma client initialized successfully")
+
+
+async def setup_test_data():
+    """Create test collection and add test data"""
+    collection_name = "test_get_documents"
+
+    # Create collection
+    result = await chroma_create_collection(collection_name)
+    print(f"📦 {result}")
+
+    # Add test documents
+    documents = [
+        "Python is a high-level programming language",
+        "JavaScript is the core language for web development",
+        "Chroma is a vector database",
+        "MCP stands for Model Context Protocol",
+        "FastAPI is a high-performance Python web framework",
+    ]
+    ids = [f"doc_{i}" for i in range(1, len(documents) + 1)]
+    metadatas = [
+        {"category": "programming", "language": "python", "difficulty": 3},
+        {"category": "programming", "language": "javascript", "difficulty": 4},
+        {"category": "database", "language": "python", "difficulty": 5},
+        {"category": "protocol", "language": "general", "difficulty": 2},
+        {"category": "framework", "language": "python", "difficulty": 4},
+    ]
+
+    result = await chroma_add_documents(
+        collection_name=collection_name,
+        documents=documents,
+        ids=ids,
+        metadatas=metadatas,
+    )
+    print(f"📝 {result}")
+    return collection_name
+
+
+async def test_get_all_documents(collection_name: str):
+    """Test 1: Get all documents (no filter)"""
+    print("\n--- Test 1: Get all documents ---")
+    result = await chroma_get_documents(collection_name=collection_name)
+    print(f"Returned document count: {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    print(f"Documents: {result.get('documents')}")
+    assert len(result.get('ids', [])) == 5, f"Expected 5 documents, got {len(result.get('ids', []))}"
+    print("✅ Test 1 passed")
+
+
+async def test_get_by_ids(collection_name: str):
+    """Test 2: Get documents by IDs"""
+    print("\n--- Test 2: Get documents by IDs ---")
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        ids=["doc_1", "doc_3", "doc_5"],
+    )
+    print(f"Returned document count: {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    assert len(result.get('ids', [])) == 3
+    assert "doc_1" in result.get('ids', [])
+    assert "doc_3" in result.get('ids', [])
+    assert "doc_5" in result.get('ids', [])
+    print("✅ Test 2 passed")
+
+
+async def test_get_by_metadata_filter(collection_name: str):
+    """Test 3: Filter by metadata (where condition)"""
+    print("\n--- Test 3: Filter by metadata ---")
+    # Filter language == "python"
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        where='{"language": "python"}',
+    )
+    print(f"Documents with language=python: {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    assert len(result.get('ids', [])) == 3  # doc_1, doc_3, doc_5
+    print("✅ Test 3 passed")
+
+
+async def test_get_by_metadata_comparison(collection_name: str):
+    """Test 4: Filter by metadata comparison operators ($gt, $eq, etc.)"""
+    print("\n--- Test 4: Filter by metadata comparison ---")
+    # Filter difficulty >= 4
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        where='{"difficulty": {"$gte": 4}}',
+    )
+    print(f"Documents with difficulty >= 4: {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    assert len(result.get('ids', [])) == 3  # doc_2(4), doc_3(5), doc_5(4)
+    print("✅ Test 4 passed")
+
+
+async def test_get_by_document_content_filter(collection_name: str):
+    """Test 5: Filter by document content (where_document)"""
+    print("\n--- Test 5: Filter by document content ---")
+    # Filter documents containing "Python"
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        where_document='{"$contains": "Python"}',
+    )
+    print(f"Documents containing 'Python': {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    print(f"Documents: {result.get('documents')}")
+    # doc_1: "Python is a high-level programming language", doc_5: "FastAPI is a high-performance Python web framework"
+    assert len(result.get('ids', [])) == 2
+    print("✅ Test 5 passed")
+
+
+async def test_get_with_limit_offset(collection_name: str):
+    """Test 6: Pagination (limit + offset)"""
+    print("\n--- Test 6: Pagination ---")
+    # Page 1: first 2 items
+    result_page1 = await chroma_get_documents(
+        collection_name=collection_name,
+        limit=2,
+        offset=0,
+    )
+    print(f"Page 1 (limit=2, offset=0): {len(result_page1.get('ids', []))} items")
+    print(f"IDs: {result_page1.get('ids')}")
+
+    # Page 2: skip 2, take 2
+    result_page2 = await chroma_get_documents(
+        collection_name=collection_name,
+        limit=2,
+        offset=2,
+    )
+    print(f"Page 2 (limit=2, offset=2): {len(result_page2.get('ids', []))} items")
+    print(f"IDs: {result_page2.get('ids')}")
+
+    assert len(result_page1.get('ids', [])) == 2
+    assert len(result_page2.get('ids', [])) == 2
+    # IDs across pages should not overlap
+    page1_ids = set(result_page1.get('ids', []))
+    page2_ids = set(result_page2.get('ids', []))
+    assert page1_ids.isdisjoint(page2_ids), "Pagination results should not overlap"
+    print("✅ Test 6 passed")
+
+
+async def test_get_custom_include(collection_name: str):
+    """Test 7: Custom include parameter"""
+    print("\n--- Test 7: Custom include parameter ---")
+    # Only return IDs, no document content or metadata
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        ids=["doc_1"],
+        include=[],  # Don't include any extra content
+    )
+    print(f"include=[] result: {result}")
+    assert "ids" in result
+    # documents and metadatas should not be in the result
+    print("✅ Test 7 passed")
+
+
+async def test_get_empty_ids(collection_name: str):
+    """Test 8: Pass empty ids list (expected to raise exception)"""
+    print("\n--- Test 8: Pass empty ids list ---")
+    try:
+        result = await chroma_get_documents(
+            collection_name=collection_name,
+            ids=[],
+        )
+        print(f"Empty ids returned: {result}")
+        # If no exception, accept empty result
+        assert len(result.get('ids', [])) == 0
+    except Exception as e:
+        # ChromaDB does not allow empty ids list, will raise exception, this is expected
+        print(f"Empty ids expected exception: {e}")
+    print("✅ Test 8 passed")
+
+
+async def test_get_nonexistent_id(collection_name: str):
+    """Test 9: Query non-existent document ID"""
+    print("\n--- Test 9: Query non-existent document ID ---")
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        ids=["nonexistent_id"],
+    )
+    print(f"Non-existent ID returned: {result}")
+    assert len(result.get('ids', [])) == 0
+    print("✅ Test 9 passed")
+
+
+async def test_get_combined_filters(collection_name: str):
+    """Test 10: Combine where and where_document filters"""
+    print("\n--- Test 10: Combined filter conditions ---")
+    result = await chroma_get_documents(
+        collection_name=collection_name,
+        where='{"language": "python"}',
+        where_document='{"$contains": "Python"}',
+    )
+    print(f"Documents with language=python and containing 'Python': {len(result.get('ids', []))}")
+    print(f"IDs: {result.get('ids')}")
+    # doc_1: Python is a high-level programming language (language=python, contains Python)
+    # doc_3: Chroma is a vector database (language=python, does not contain Python)
+    # doc_5: FastAPI is a high-performance Python web framework (language=python, contains Python)
+    assert len(result.get('ids', [])) == 2
+    print("✅ Test 10 passed")
+
+
+async def cleanup(collection_name: str):
+    """Clean up test data"""
+    print(f"\n🧹 Cleaning up test collection: {collection_name}")
+    try:
+        await chroma_delete_collection(collection_name)
+        print("✅ Cleanup complete")
+    except Exception as e:
+        print(f"⚠️ Cleanup failed: {e}")
+
+
+async def main():
+    """Run all tests"""
+    print("=" * 60)
+    print("🧪 chroma_get_documents method tests")
+    print("=" * 60)
+
+    init_client()
+    collection_name = await setup_test_data()
+
+    tests = [
+        ("Get all documents", test_get_all_documents),
+        ("Get by IDs", test_get_by_ids),
+        ("Metadata filter", test_get_by_metadata_filter),
+        ("Metadata comparison filter", test_get_by_metadata_comparison),
+        ("Document content filter", test_get_by_document_content_filter),
+        ("Pagination", test_get_with_limit_offset),
+        ("Custom include", test_get_custom_include),
+        ("Empty ids list", test_get_empty_ids),
+        ("Non-existent ID", test_get_nonexistent_id),
+        ("Combined filters", test_get_combined_filters),
+    ]
+
+    passed = 0
+    failed = 0
+
+    for name, test_func in tests:
+        try:
+            await test_func(collection_name)
+            passed += 1
+        except Exception as e:
+            failed += 1
+            print(f"❌ Test failed [{name}]: {e}")
+
+    await cleanup(collection_name)
+
+    print("\n" + "=" * 60)
+    print(f"📊 Test results: {passed} passed, {failed} failed, {len(tests)} total")
+    print("=" * 60)
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = asyncio.run(main())
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Bug Information
The input of `where_document` parameter was converted into a `string` value instead of the `WhereDocument` class object that the `chromadb` required when my agent tried to using the `chroma_get_document` tool.
```
For example: input where_document: {"$contains": "SY7304"}(object) happened to be "{\"$contains\": \"SY7304\"}"(string)
```

## Problem
I find out the generated schema of Dict variables is:
```
 {anyOf: [{additionalProperties:true, type:"object"}, {type:"null"}]}
```
And the `additionalProperties:true` without a specific desciption is literally confusing the LLM, which incurs a tool calling variable type of `string`.

## Solution
1. I replaced the input parameter type of the `chroma_get_document` method with `string`, then impleted an extra function `_parse_dict_param` to parse a `string` value into a `Dict` value. That way the generated schemta would keep specifical for LLM.
```
{anyOf: [{type:"string"}, {type:"null"}]}
```
2. To keep the compatibility of original `Dict` type variables, I use `str | Dict | None = None`.

## About Test
Use `tests/test_chroma_get_documents.py` for unit test.